### PR TITLE
Better VRAM Math

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -53,7 +53,20 @@ fi
 
 gpu_ram() {
 	# Prints all GPUs' memory in GB
-	nvidia-smi --query-gpu=memory.total --format=csv,noheader | awk '{ printf "%.0f\n", $1 / 1000 }' | head -n1
+	nvidia-smi --query-gpu=memory.total --format=csv,noheader |
+		awk '{ printf "%.0f\n", $1 / 1024 }' | head -n1
+	# NVidia-SMI reports in MiB.
+	# 1GB = 953.674MiB
+	# 2070 Max-Q       advertised:  8GB - NVidia-SMI: 7,982MiB  or  8.4GB or  7.8GiB
+	# GTX Titan        advertised: 12GB - NVidia-SMI: 12,212MiB or 12.8GB or 11.9GiB
+	# Titan  RTX       advertised: 24GB - NVidia-SMI: 24,219MiB or 25.4GB or 23.7GiB
+	# Quadro RTX 8000  advertised: 48GB - NVidia-SMI: 48,601MiB or 51.0GB or 47.5GiB
+
+	# awk 'END {printf "%.0f\n", 0.49 }' = 0
+	# awk 'END {printf "%.0f\n", 0.5  }' = 1
+	# awk 'END {print  int(0.49)      }' = 0
+	# awk 'END {print  int(0.5)       }' = 0
+
 	# head -n1 becuase we're assuming all GPUs have the same capacity.
 	# It might be interesting to explore supporting different GPUs in the same machine but not right now
 }

--- a/config.sh
+++ b/config.sh
@@ -5,7 +5,7 @@ PRECISION="fp32 fp16"
 RUN_MODE="train inference"
 DATA_MODE="syn"
 
-case "${GPU_RAM:-'12GB'}" in
+case "${GPU_RAM}" in
 	'6GB') 
 		resnet50=32
 		resnet152=16
@@ -24,7 +24,7 @@ case "${GPU_RAM:-'12GB'}" in
 		alexnet=384
 		ssd300=32
 		;;
-	'12GB')
+	'11GB'|'12GB') # 11GB for 2080Ti
 		resnet50=64
 		resnet152=32
 		inception3=64
@@ -51,7 +51,7 @@ case "${GPU_RAM:-'12GB'}" in
 		alexnet=1536
 		ssd300=96
 		;;
-	'48GB')
+	'47GB'|'48GB') # 47GB for Quadro RTX
 		resnet50=256
                 resnet152=128
                 inception3=256
@@ -60,5 +60,11 @@ case "${GPU_RAM:-'12GB'}" in
                 alexnet=2048
                 ssd300=128
 		;;
-	*) echo "Batchsize for VRAM size '$GPU_RAM' not optimized" >&2;;
+	*)
+		cat 1>&2 <<- EOF
+		Batchsize for VRAM size $GPU_RAM is not optimized.
+		Try adding $GPU_RAM to the case statement in config.sh.
+		EOF
+		exit 1
+		;;
 esac


### PR DESCRIPTION
|Name             |Advertised|NVidia-SMI |GB      |GiB      |
|-----------------|----------|-----------|--------|---------|
|2070 Max-Q       |  8GB     | 7,982MiB  |  8.4 |  7.8 |
|GTX Titan        | 12GB     | 12,212MiB | 12.8 | 11.9 |
|Titan  RTX       | 24GB     | 24,219MiB | 25.4 | 23.7 |
|Quadro RTX 8000  | 48GB     | 48,601MiB | 51.0 | 47.5 |

The benchmark script will use GiB rounded to the nearest integer for batch size configurations.