### PR TITLE
Make shebang compatible with other distros

### DIFF
--- a/batch_benchmark.sh
+++ b/batch_benchmark.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -eEu
 
 MIN_NUM_GPU=${1:-1}
 MAX_NUM_GPU=${2:-1}

--- a/batch_report.sh
+++ b/batch_report.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -eEu
 
 REPORT_DIR=$1
 

--- a/deploy_dist.sh
+++ b/deploy_dist.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -eEu
 
 # Manually
 # ./dist_benchmark.sh 0,1,2,3 1 10.0.0.1:50000,10.0.0.2:50000 10.0.0.1:50001,10.0.0.2:50001 0

--- a/dist_benchmark.sh
+++ b/dist_benchmark.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -eEu
 
 GPU_INDEX=${1:-0}
 IFS=', ' read -r -a gpus <<< "$GPU_INDEX"

--- a/gether.sh
+++ b/gether.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -eEu
 
 MIN_NUM_GPU=${1:-1}
 MAX_NUM_GPU=${2:-8}

--- a/local_deploy_dist.sh
+++ b/local_deploy_dist.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -eEu
 
 GPU_INDEX=0,1,2,3
 ITERATIONS=1

--- a/report.sh
+++ b/report.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env sh
+
+set -eu
 
 if [ "$#" -lt 1 ] || [ ! -d "$1" ]; then
 	echo "${0##*/}: provide a directory as the first argument"


### PR DESCRIPTION
Replacing hardcoded paths to bash and sh to use /usr/bin/env instead.
This makes the scripts it compatible with other distros as well.

This requires to move the "-e" into a "set -e" though.