### PR TITLE
Make shebang compatible with other distros

### DIFF
--- a/batch_benchmark.sh
+++ b/batch_benchmark.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -eEu
 
 MIN_NUM_GPU=${1:-1}
 MAX_NUM_GPU=${2:-1}

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -e 
+#!/usr/bin/env bash
+
+set -eEu
+
 GPU_INDEX=${1:-0}
 IFS=', ' read -r -a gpus <<< "$GPU_INDEX"
 

--- a/config/bs_fp16.sh
+++ b/config/bs_fp16.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 case "${GPU_RAM:-'12GB'}" in
 	'6GB') 

--- a/config/bs_fp32.sh
+++ b/config/bs_fp32.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 case "${GPU_RAM:-'12GB'}" in
 	'6GB') 

--- a/config/config_all.sh
+++ b/config/config_all.sh
@@ -1,7 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env sh
 MODELS="inception3 resnet152 resnet50 alexnet inception4 vgg16"
 VARIABLE_UPDATE="replicated"
 PRECISION="fp16 fp32"
 RUN_MODE="train inference"
 DATA_MODE="syn"
-

--- a/config/config_debug.sh
+++ b/config/config_debug.sh
@@ -1,7 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env sh
 MODELS="resnet152"
 VARIABLE_UPDATE="replicated"
 PRECISION="fp16"
 RUN_MODE="train"
 DATA_MODE="syn"
-

--- a/config/config_inception3.sh
+++ b/config/config_inception3.sh
@@ -1,7 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env sh
 MODELS="inception3"
 VARIABLE_UPDATE="replicated"
 PRECISION="fp32 fp16"
 RUN_MODE="train"
 DATA_MODE="syn"
-

--- a/config/config_resnet152_replicated_train_syn.sh
+++ b/config/config_resnet152_replicated_train_syn.sh
@@ -1,7 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env sh
 MODELS="resnet152"
 VARIABLE_UPDATE="replicated"
 PRECISION="fp16 fp32"
 RUN_MODE="train"
 DATA_MODE="syn"
-

--- a/config/config_resnet50_replicated_fp16_train_syn.sh
+++ b/config/config_resnet50_replicated_fp16_train_syn.sh
@@ -1,7 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env sh
 MODELS="resnet50"
 VARIABLE_UPDATE="replicated"
 PRECISION="fp16"
 RUN_MODE="train"
 DATA_MODE="syn"
-

--- a/config/config_resnet50_replicated_fp32_train_syn.sh
+++ b/config/config_resnet50_replicated_fp32_train_syn.sh
@@ -1,7 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env sh
 MODELS="resnet50"
 VARIABLE_UPDATE="replicated"
 PRECISION="fp32"
 RUN_MODE="train"
 DATA_MODE="syn"
-


### PR DESCRIPTION
@chuanli11 Another try for #17.

Replacing hardcoded paths to bash and sh to use /usr/bin/env instead.
This makes the scripts compatible with other distros as well.

This requires moving the "-e" into a "set -e" though.